### PR TITLE
SingleVM: Test SSH connectivity via External IP

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1009,8 +1009,16 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 			Operand: ssntp.PublicIPAssigned,
 			Dest:    ssntp.Controller,
 		},
+		{ // all AssignPublicIPFailure events go to all Controllers
+			Operand: ssntp.AssignPublicIPFailure,
+			Dest:    ssntp.Controller,
+		},
 		{ // all PublicIPUnassigned events go to all Controllers
 			Operand: ssntp.PublicIPUnassigned,
+			Dest:    ssntp.Controller,
+		},
+		{ // all UnassignPublicIPFailure events go to all Controllers
+			Operand: ssntp.UnassignPublicIPFailure,
 			Dest:    ssntp.Controller,
 		},
 		{ // all START command are processed by the Command forwarder

--- a/networking/ciao-cnci-agent/client.go
+++ b/networking/ciao-cnci-agent/client.go
@@ -201,9 +201,11 @@ func processCommand(client *ssntpConn, cmd *cmdWrapper) {
 			err := assignPubIP(c)
 			if err != nil {
 				glog.Errorf("Error Processing: CiaoCommandAssignPublicIP %v", err)
+				err = sendNetworkError(client, ssntp.AssignPublicIPFailure, c)
+			} else {
+				err = sendNetworkEvent(client, ssntp.PublicIPAssigned, c)
 			}
 
-			err = sendNetworkEvent(client, ssntp.PublicIPAssigned, c)
 			if err != nil {
 				glog.Errorf("Unable to send event : %v", err)
 			}
@@ -217,9 +219,11 @@ func processCommand(client *ssntpConn, cmd *cmdWrapper) {
 			err := releasePubIP(c)
 			if err != nil {
 				glog.Errorf("Error Processing: CiaoCommandReleasePublicIP %v", c)
+				err = sendNetworkError(client, ssntp.UnassignPublicIPFailure, c)
+			} else {
+				err = sendNetworkEvent(client, ssntp.PublicIPUnassigned, c)
 			}
 
-			err = sendNetworkEvent(client, ssntp.PublicIPUnassigned, c)
 			if err != nil {
 				glog.Errorf("Unable to send event : %v", err)
 			}

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -546,6 +546,10 @@ const (
 	// AssignPublicIPFailure is sent by the CNCI when a an external IP
 	// cannot be assigned.
 	AssignPublicIPFailure
+
+	// UnassignPublicIPFailure is sent by the CNCI when a an external IP
+	// cannot be unassigned.
+	UnassignPublicIPFailure
 )
 
 // Major is the SSNTP protocol major version


### PR DESCRIPTION
Add error reporting paths from CNCI to controller.

Test the external IP connectivity using SSH. This ensures that the external IP can be used to reach the instance. 

Enhance the setup scripts to setup a unique ssh key for a given test run. This can be used in the future to eliminate the need to have the password setup in the cloud-init. Enhance the scripts to check for the error reporting paths.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>